### PR TITLE
Use raw string to eliminate warning

### DIFF
--- a/Part1_TokensEmbeddings/text2numbers/part1_text2num_text2numbers.ipynb
+++ b/Part1_TokensEmbeddings/text2numbers/part1_text2num_text2numbers.ipynb
@@ -73,7 +73,7 @@
       "source": [
         "# separate into words by splitting by spaces\n",
         "import re\n",
-        "re.split('\\s',text[0])"
+        "re.split(r'\\s',text[0])"
       ],
       "metadata": {
         "id": "83q3ZHR6HuSd"


### PR DESCRIPTION
This fix eliminates the following warning:
SyntaxWarning: invalid escape sequence '\s'