### PR TITLE
Fix SyntaxWarning messages

### DIFF
--- a/Part1_TokensEmbeddings/text2numbers/part1_text2num_text2numbers.ipynb
+++ b/Part1_TokensEmbeddings/text2numbers/part1_text2num_text2numbers.ipynb
@@ -73,7 +73,7 @@
       "source": [
         "# separate into words by splitting by spaces\n",
         "import re\n",
-        "re.split('\\s',text[0])"
+        "re.split(r'\\s',text[0])"
       ],
       "metadata": {
         "id": "83q3ZHR6HuSd"
@@ -85,7 +85,7 @@
       "cell_type": "code",
       "source": [
         "# can recombine into a text\n",
-        "' '.join( re.split('\\s',text[0]) )"
+        "' '.join( re.split(r'\\s',text[0]) )"
       ],
       "metadata": {
         "id": "F3xIl0TZHuPx"
@@ -97,7 +97,7 @@
       "cell_type": "code",
       "source": [
         "# also make lower-case\n",
-        "allwords = re.split('\\s',' '.join(text).lower())\n",
+        "allwords = re.split(r'\\s',' '.join(text).lower())\n",
         "allwords"
       ],
       "metadata": {


### PR DESCRIPTION
Use raw strings to eliminate SyntaxWarning messages in three places.